### PR TITLE
URGENT: remove type:module from package.json

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "app.js",
-  "type": "module",
-   "scripts": {
+  "scripts": {
     "start": "nodemon app.ts",
     "dev": "ts-node-dev app.ts",
     "test": "jest",


### PR DESCRIPTION
I don't know what kind of actions added "type":"module" to package.json, but I found that this makes the compiler does not recognize the typescript files. 