### PR TITLE
Adds scaffolding for referral creation modal

### DIFF
--- a/frontend/src/components/ReferralCreationModal/ReferralCreationModal.tsx
+++ b/frontend/src/components/ReferralCreationModal/ReferralCreationModal.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react'
+import { Button, Modal, ModalProps, Paper, Step, Stepper, Typography, StepLabel, Box } from '@mui/material'
+// @ts-ignore
+import { JobPost } from '../../../../backend/node_modules/@prisma/client'
+
+interface ReferralCreationModalProps {
+  jobPost: JobPost
+}
+
+const style = {
+  position: 'absolute' as 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 600,
+  p: 4,
+}
+
+export default function ReferralCreationModal(props: ReferralCreationModalProps & Omit<ModalProps, 'children'>) {
+  const { jobPost, ...modalProps } = props
+  const [activeStep, setActiveStep] = useState(0)
+
+  const handleBack = () => {
+    if (activeStep === 0) return
+    setActiveStep(activeStep - 1)
+  }
+
+  const handleNext = () => {
+    if (activeStep === steps.length) return handleSubmit()
+    setActiveStep(activeStep + 1)
+  }
+
+  const handleSubmit = () => {
+    // TODO
+  }
+
+  const steps = ['Personal', 'Reccomendation', 'Documents', 'Review']
+
+  return (
+    <Modal {...modalProps}>
+      <Paper sx={style}>
+        <Typography variant='h5'>Referral for {jobPost?.title}</Typography>
+        <Box sx={{height: '500px'}}>
+
+        </Box>
+        <Stepper activeStep={activeStep}>
+          {steps.map((label, i) => {
+            return (
+              <Step key={i}>
+                <StepLabel>{label}</StepLabel>
+              </Step>
+            )
+          })}
+        </Stepper>
+        <Box display='flex' justifyContent='space-evenly' mt={2}>
+          <Button size='small' onClick={() => handleBack()}>
+            Back
+          </Button>
+          <Button size='small' variant='contained' onClick={() => handleNext()}>
+            {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+          </Button>
+        </Box>
+      </Paper>
+    </Modal>
+  )
+}

--- a/frontend/src/components/ReferralCreationModal/index.tsx
+++ b/frontend/src/components/ReferralCreationModal/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ReferralCreationModal'

--- a/frontend/src/pages/JobFeed/components/JobCard.tsx
+++ b/frontend/src/pages/JobFeed/components/JobCard.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react'
 import { Button, Paper, Typography } from '@mui/material'
 import { Box } from '@mui/system'
 // @ts-ignore
 import { JobPost } from '../../../../../backend/node_modules/prisma/prisma-client'
 import ValueWithLabel from '../../../components/ValueWithLabel'
+import ReferralCreationModal from '../../../components/ReferralCreationModal'
 
 interface JobCardProps {
   job: JobPost
@@ -10,6 +12,7 @@ interface JobCardProps {
 
 export default function JobCard(props: JobCardProps) {
   const { job } = props
+  const [referralCreationModalOpen, setReferralCreationModalOpen] = useState(false)
   const JobCardContent = job ? (
     <Box height='100%' display='flex' flexDirection='column'>
       <Box flexGrow={1}>
@@ -24,12 +27,17 @@ export default function JobCard(props: JobCardProps) {
         <ValueWithLabel label='Experience' value={job?.minYearsExperience} />
         <ValueWithLabel label='Openings' value={job?.openings} />
       </Box>
-      <Button variant='contained' color='primary'>
+      <Button onClick={() => setReferralCreationModalOpen(true)} variant='contained' color='primary'>
         Refer
       </Button>
     </Box>
   ) : (
     <Typography>Click on a job to learn more!</Typography>
   )
-  return <Paper sx={{ mx: 2, p: 2, height: '100%' }}>{JobCardContent}</Paper>
+  return (
+    <Paper sx={{ mx: 2, p: 2, height: '100%' }}>
+      {JobCardContent}
+      <ReferralCreationModal open={referralCreationModalOpen} onClose={() => setReferralCreationModalOpen(false)} jobPost={job} />
+    </Paper>
+  )
 }


### PR DESCRIPTION
Creates a skeleton for the referral modal and links it up with the "Refer" button that you see when looking at a job on the `/jobs` route