### PR TITLE
Sort job posts globally, not by page

### DIFF
--- a/backend/controllers/jobPostControllers.ts
+++ b/backend/controllers/jobPostControllers.ts
@@ -93,7 +93,8 @@ const whereClauseBuilder = (args: Partial<JobListingFilterType>) => {
 const prisma = new PrismaClient();
 
 export const getJobPostings = async (
-  filters: Partial<JobListingFilterType> & { page: number }
+  filters: Partial<JobListingFilterType> & { page: number },
+  orderBy: Prisma.JobPostOrderByWithRelationInput,
 ) => {
   const PAGE_SIZE = 10;
   const { page, ...whereClauseFilters } = filters;
@@ -101,6 +102,7 @@ export const getJobPostings = async (
 
   const data = await prisma.jobPost.findMany({
     where: whereClause,
+    orderBy,
     skip: page * PAGE_SIZE,
     take: PAGE_SIZE,
     include: {

--- a/backend/prisma/factories.ts
+++ b/backend/prisma/factories.ts
@@ -76,6 +76,7 @@ export const createJobPost = async (
   const minYearsExperience = faker.datatype.number(10);
   const salary = faker.datatype.number(150000);
   const openings = faker.datatype.number(3) + 1;
+  const createdDate = faker.date.recent(365 * 10);
 
   const defaultData = {
     title,
@@ -84,6 +85,7 @@ export const createJobPost = async (
     minYearsExperience,
     salary,
     openings,
+    createdDate,
   };
 
   const res = await prisma.jobPost.create({

--- a/frontend/src/pages/JobFeed/JobFeed.tsx
+++ b/frontend/src/pages/JobFeed/JobFeed.tsx
@@ -17,7 +17,7 @@ interface JobFeedResponseType {
 export default function JobFeed() {
   enum sortStatus {
     ASC = "asc",
-    DEC = "dec",
+    DEC = "desc",
   }
   const PAGE_SIZE = 10;
   const [selectedJob, setSelectedJob] = useState<any>(null);
@@ -44,6 +44,8 @@ export default function JobFeed() {
       minExperience,
       maxExperience,
       page,
+      sortBy: 'createdDate',
+      sortDirection: selectedSort,
     },
   });
 
@@ -52,13 +54,11 @@ export default function JobFeed() {
   const drawerWidth = 270;
 
   //sorts data ascending or descending by createdDate
-  function handleChange() {
+  function reverseSort() {
     if (selectedSort === sortStatus.ASC) {
       setSelectedSort(sortStatus.DEC);
-      data?.data?.sort((a, b) => a.createdDate.localeCompare(b.createdDate));
     } else {
       setSelectedSort(sortStatus.ASC);
-      data?.data?.sort((a, b) => b.createdDate.localeCompare(a.createdDate));
     }
   }
   //returns up or down button depending on selected sort
@@ -95,7 +95,7 @@ export default function JobFeed() {
       >
         <Box sx={{ gridArea: "sort" }} my={1}>
           <Typography variant="button">{"Sort by Date: "}</Typography>
-          <IconButton onClick={() => handleChange()}>
+          <IconButton onClick={reverseSort}>
             {getIcon(selectedSort)}
           </IconButton>
           <Typography>{data?.numResults || 0} results</Typography>


### PR DESCRIPTION
Currently only works for date (as that's all that's supported by the frontend),
but written in a way to be amenable to other fields.

This moves the sorting to the backend.